### PR TITLE
MNIST_softmax的一个error

### DIFF
--- a/SOURCE/tutorials/mnist/mnist_softmax.py
+++ b/SOURCE/tutorials/mnist/mnist_softmax.py
@@ -15,11 +15,13 @@ sess = tf.InteractiveSession()
 x = tf.placeholder("float", [None, 784])
 W = tf.Variable(tf.zeros([784,10]))
 b = tf.Variable(tf.zeros([10]))
-y = tf.nn.softmax(tf.matmul(x,W) + b)
+#y = tf.nn.softmax(tf.matmul(x,W) + b)  # this will be lead an error because of log(0)
+y = tf.nn.log_softmax(tf.matmul(x,W) + b)
 
 # Define loss and optimizer
 y_ = tf.placeholder("float", [None,10])
-cross_entropy = -tf.reduce_sum(y_*tf.log(y))
+#cross_entropy = -tf.reduce_sum(y_*tf.log(y))
+cross_entropy = -tf.reduce_sum(y_*y)
 train_step = tf.train.GradientDescentOptimizer(0.01).minimize(cross_entropy)
 
 # Train


### PR DESCRIPTION
直接使用tf.nn.softmax(tf.matmul(x, W) + b)计算类别概率会导致tf.log(y)出现log(0)的错误
